### PR TITLE
Implement live statistics

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -22,5 +22,16 @@
     "mention_roles": [
       "12323"
     ]
+  },
+  "activity": {
+    "channel_id": "123",
+    "title": "Belux VATSIM",
+    "airports": [
+      "EBBR",
+      "ELLX"
+    ],
+    "additional_prefixes": [
+      "EBBU"
+    ]
   }
 }

--- a/src/events/handlers/ready.ts
+++ b/src/events/handlers/ready.ts
@@ -2,11 +2,13 @@ import {Client} from '../../types/client';
 
 import {Events} from 'discord.js';
 import {EventHandler} from "../events";
+import {liveStats} from "../../workers/live-stats";
 
 export default {
     name: Events.ClientReady,
     once: true,
-    execute(client: Client) {
+    async execute(client: Client) {
         console.log(`Ready! Logged in as ${client.user.tag}`);
+        await liveStats(client);
     },
 } as EventHandler;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -16,5 +16,11 @@ export interface Config {
     },
     loa: {
         mention_roles: string[]
+    },
+    activity: {
+        channel_id: string,
+        title: string,
+        airports: string[],
+        additional_prefixes: string[]
     }
 }

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -2,14 +2,16 @@ import path from "path";
 import {Config} from "../types/config";
 import fs from "fs";
 
-if (!global.config) {
+let config: Config = global.config;
+if (!config) {
     let argConfigPath = process.argv.find(x => x.startsWith('betty_config='))
             ?.replace('betty_config=', '');
     if (argConfigPath.startsWith('.')) {
         argConfigPath = path.join(__dirname, argConfigPath);
     }
     const configPath = argConfigPath ?? path.join(__dirname, 'config.json');
-    global.config = <Config>JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    config = <Config>JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    global.config = config;
 }
-export default global.config satisfies Config;
+export default config satisfies Config;
 

--- a/src/util/timestamp.ts
+++ b/src/util/timestamp.ts
@@ -1,14 +1,14 @@
-type TimestampFormat =
-    | 'F'
-    | 'f'
-    | 'D'
-    | 'd'
-    | 't'
-    | 'T'
-    | 'R'
-    ;
+export enum TimestampFormat {
+    Full = 'F',
+    DateTime = 'f',
+    HumanDate = 'D',
+    Date = 'd',
+    Time = 't',
+    TimeSeconds = 'T',
+    Relative = 'R'
+}
 
-export function makeTimestamp(dateParseable: string, format: TimestampFormat = 'f'): string {
+export function makeTimestamp(dateParseable: string, format: TimestampFormat = TimestampFormat.DateTime): string {
     const ts = (new Date(dateParseable).getTime() / 1000).toFixed(0);
-    return `<t:${ts}:${format}>`;
+    return `<t:${ts}:${format.toString()}>`;
 }

--- a/src/workers/live-stats.ts
+++ b/src/workers/live-stats.ts
@@ -1,0 +1,132 @@
+import {Client} from "../types/client";
+import {APIEmbedField, BaseGuildTextChannel, EmbedBuilder} from "discord.js";
+import {makeTimestamp, TimestampFormat} from "../util/timestamp";
+import config from "../util/config";
+import atis from "../commands/basic/atis";
+
+function aggregateAirport(icao: string, data: any): APIEmbedField[] {
+    const flightPlans = data['pilots'].filter(x => x['flight_plan'] != null).map(x => x['flight_plan']);
+    const arrivals = flightPlans.filter(x => x['arrival'] === icao).length;
+    const departures = flightPlans.filter(x => x['departure'] === icao).length;
+
+    if (arrivals + departures == 0) {
+        return [];
+    }
+
+    return [
+        {
+            name: ' ',
+            value: icao,
+            inline: true
+        },
+        {
+            name: '🛫',
+            value: departures.toString(),
+            inline: true
+        },
+        {
+            name: '🛬',
+            value: arrivals.toString(),
+            inline: true
+        }
+    ];
+}
+
+function prefixMatches(callsign: string): boolean {
+    const prefix = callsign.split('_')[0];
+    return config.activity.airports.findIndex(x => x === prefix) !== -1
+        || config.activity.additional_prefixes.findIndex(x => x === prefix) !== -1;
+}
+
+function getControllerFields(data: any): APIEmbedField[] {
+    return data['controllers']
+        .filter(x => prefixMatches(x['callsign']))
+        .filter(controller => controller['frequency'] !== '199.998')
+        .map(controller => ({
+                name: `🟢 ${controller['callsign']}`,
+                value: `${controller['frequency']} | [${controller['name']}](https://stats.vatsim.net/stats/${controller['cid']})`,
+                inline: false
+        }));
+}
+
+function getAtisFields(data: any): APIEmbedField[] {
+    return data['atis']
+        .filter(atis => prefixMatches(atis['callsign']))
+        .map(atis => {
+            const atis_letter = atis['atis_code'].toLowerCase();
+            return {
+                name: `:regional_indicator_${atis_letter}: ${atis['callsign']}`,
+                value: atis['frequency'],
+                inline: false
+            };
+        });
+}
+
+export async function liveStats(client: Client): Promise<void> {
+    if (config.activity.channel_id.length === 0)
+        return;
+
+    const channel = await client.channels.fetch(config.activity.channel_id);
+    if (channel === null) {
+        console.warn("Live stat channel not found.");
+        return;
+    }
+    if (!(channel instanceof BaseGuildTextChannel)) {
+        console.warn("Live stat channel not a text channel");
+        return;
+    }
+
+    const response = await fetch('https://data.vatsim.net/v3/vatsim-data.json');
+    if (!response.ok) {
+        console.warn(`Got code ${response.status} from VATSIM datafile`);
+        return;
+    }
+    const datafile = await response.json();
+    const relatime = makeTimestamp(datafile['general']['update_timestamp'], TimestampFormat.Relative)
+
+    const airportFields = config.activity.airports
+        .flatMap(icao => aggregateAirport(icao, datafile))
+    const atisFields = getAtisFields(datafile);
+    const controllerFields = getControllerFields(datafile);
+
+    const airportEmbed = new EmbedBuilder()
+        .setColor(0x289fb8)
+        .setTimestamp()
+        .setTitle(`${config.activity.title} ${relatime}`)
+        .addFields(...airportFields);
+
+    const atcEmbed = new EmbedBuilder()
+        .setColor(0x289fb8)
+        .setTimestamp()
+        .setTitle('ATC')
+        .addFields(...getControllerFields(datafile));
+
+    const atisEmbed = new EmbedBuilder()
+        .setColor(0x289fb8)
+        .setTimestamp()
+        .setTitle('ATIS')
+        .addFields(...atisFields);
+
+    const botMessages = (await channel.messages.fetch())
+        .map(m => m ) // Makes it an array
+        .filter(m => m.author.id === client.user.id);
+
+    let embeds = [airportEmbed];
+    if (controllerFields.length > 0) {
+        embeds.push(atcEmbed);
+    }
+    if (atisFields.length > 0) {
+        embeds.push(atisEmbed);
+    }
+
+    if (botMessages.length < 1) {
+        await channel.send({
+            embeds: embeds
+        });
+    } else {
+        await botMessages[0].edit({
+            embeds: embeds
+        });
+    }
+
+}


### PR DESCRIPTION
Configurable via the config file of course,
fetches movements, controllers and ATIS from the datafile and displays this in a live-updating set of embeds.

I chose to use three embeds, shown when there is data, to avoid ever hitting the fields-per-embed limit.

Theoretically still possible to hit it if there's more thatn 25 ATIS'es or controllers, but this seems unlikely.

Update runs on startup and every 15 minutes afterwards.