### PR TITLE
Fix: config path parsing

### DIFF
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -6,7 +6,7 @@ let config: Config = global.config;
 if (!config) {
     let argConfigPath = process.argv.find(x => x.startsWith('betty_config='))
             ?.replace('betty_config=', '');
-    if (argConfigPath.startsWith('.')) {
+    if (argConfigPath !== undefined && argConfigPath.startsWith('.')) {
         argConfigPath = path.join(__dirname, argConfigPath);
     }
     const configPath = argConfigPath ?? path.join(__dirname, 'config.json');


### PR DESCRIPTION
Used to crash if not explicitly provided