### PR TITLE
Extract license info to separate command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "debug": "npx ts-node src/server.ts betty_config=../../config.json",
     "types": "npx tsc --noEmit",
-    "commands": "npx ts-node src/deploy-commands.ts",
+    "commands": "npx ts-node src/deploy-commands.ts betty_config=../../config.json",
     "lint": "eslint ."
   },
   "keywords": [],

--- a/src/commands/basic/help.ts
+++ b/src/commands/basic/help.ts
@@ -21,11 +21,12 @@ Right now, you can use:
 - \`/${config.name.toLowerCase()}\` to view this help
 - \`/atis\` to view an ATIS
 - \`/event\` to publish an event
+- \`/license\` for info on, well, licensing
 
 Type a command to view in-line documentation on its arguments and usage.
 
-This bot is open source and licensed under GPL3.0.
-For more info, see [GitHub](https://github.com/Epse/betty) .
+\`/atis\` is available in DMs.
+You may not have permission to run some or most commands.
 `
         });
     },

--- a/src/commands/basic/license.ts
+++ b/src/commands/basic/license.ts
@@ -1,0 +1,19 @@
+import {Command} from "../../types/command";
+import {ChatInputCommandInteraction, SlashCommandBuilder} from "discord.js";
+import {PublicAuthorization} from "../../authorization/authorize";
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName('license')
+        .setDescription('Give License information for this bot'),
+    authorizedFor: new PublicAuthorization(),
+    async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+        await interaction.reply({
+            ephemeral: true,
+            content: `
+This bot is open source and licensed under the GNU GPL v3.0.
+Copyright information, full license text and code is available on GitHub or on request.
+            `
+        });
+    }
+} satisfies Command

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -3,10 +3,12 @@ import loa from './basic/loa';
 import {Command} from "../types/command";
 import atis from "./basic/atis";
 import event from "./events/event";
+import license from "./basic/license";
 
 export default [
     help,
     loa,
     atis,
     event,
+    license,
 ] as Command[];


### PR DESCRIPTION
Also remove the GitHub link,
as some places are sensitive to advertising.

Instead, we note that source and information is available on request, which is more than sufficient for GPL compliance as long as people actually provide said information.