### PR TITLE
Pull CID from VATSIM Community API instead of server nickname

### DIFF
--- a/src/context_menu/stats.ts
+++ b/src/context_menu/stats.ts
@@ -10,7 +10,7 @@ import {cidFromDiscord} from "../util/cid_from_discord";
 const data = new ContextMenuCommandBuilder()
     .setName('Stats')
     .setType(ApplicationCommandType.User)
-    .setDMPermission(false);
+;
 
 async function execute(interaction: ContextMenuCommandInteraction): Promise<void> {
     if (!(interaction instanceof UserContextMenuCommandInteraction)) {

--- a/src/context_menu/stats.ts
+++ b/src/context_menu/stats.ts
@@ -5,27 +5,26 @@ import {
 } from "discord.js";
 import {ContextMenu} from "./context_menu";
 import {PublicAuthorization} from "../authorization/authorize";
+import {cidFromDiscord} from "../util/cid_from_discord";
 
 const data = new ContextMenuCommandBuilder()
     .setName('Stats')
     .setType(ApplicationCommandType.User)
     .setDMPermission(false);
 
-async function execute(_interaction: ContextMenuCommandInteraction): Promise<void> {
-    if (!(_interaction instanceof UserContextMenuCommandInteraction)) {
-        return;
-    }
-    const interaction = _interaction as UserContextMenuCommandInteraction;
-    const parts = ((interaction.targetMember as GuildMember).nickname).split(' - ');
-    if (parts.length !== 2) {
-        await interaction.reply({
-            ephemeral: true,
-            content: 'User does not appear to have a CID in their nick, sorry'
-        });
+async function execute(interaction: ContextMenuCommandInteraction): Promise<void> {
+    if (!(interaction instanceof UserContextMenuCommandInteraction)) {
         return;
     }
 
-    const cid = parts[1];
+    const cid = await cidFromDiscord(interaction.targetUser.id);
+    if (cid === undefined) {
+        await interaction.reply({
+            ephemeral: true,
+            content: "User does not have an associated CID through VATSIM, sorry 😞"
+        });
+        return;
+    }
 
     await interaction.reply({
         ephemeral: true,

--- a/src/context_menu/view_my.ts
+++ b/src/context_menu/view_my.ts
@@ -1,7 +1,8 @@
 import {
     ApplicationCommandType,
     ContextMenuCommandBuilder,
-    ContextMenuCommandInteraction, GuildMember, UserContextMenuCommandInteraction
+    ContextMenuCommandInteraction,
+    UserContextMenuCommandInteraction
 } from "discord.js";
 import {ContextMenu} from "./context_menu";
 import {PublicAuthorization} from "../authorization/authorize";
@@ -10,7 +11,7 @@ import {cidFromDiscord} from "../util/cid_from_discord";
 const data = new ContextMenuCommandBuilder()
     .setName('View on My Belux')
     .setType(ApplicationCommandType.User)
-    .setDMPermission(false);
+;
 
 async function execute(interaction: ContextMenuCommandInteraction): Promise<void> {
     if (!(interaction instanceof UserContextMenuCommandInteraction)) {

--- a/src/context_menu/view_my.ts
+++ b/src/context_menu/view_my.ts
@@ -5,27 +5,25 @@ import {
 } from "discord.js";
 import {ContextMenu} from "./context_menu";
 import {PublicAuthorization} from "../authorization/authorize";
+import {cidFromDiscord} from "../util/cid_from_discord";
 
 const data = new ContextMenuCommandBuilder()
     .setName('View on My Belux')
     .setType(ApplicationCommandType.User)
     .setDMPermission(false);
 
-async function execute(_interaction: ContextMenuCommandInteraction): Promise<void> {
-    if (!(_interaction instanceof UserContextMenuCommandInteraction)) {
+async function execute(interaction: ContextMenuCommandInteraction): Promise<void> {
+    if (!(interaction instanceof UserContextMenuCommandInteraction)) {
         return;
     }
-    const interaction = _interaction as UserContextMenuCommandInteraction;
-    const parts = ((interaction.targetMember as GuildMember).nickname).split(' - ');
-    if (parts.length !== 2) {
+    const cid = await cidFromDiscord(interaction.targetUser.id);
+    if (cid === undefined) {
         await interaction.reply({
             ephemeral: true,
-            content: 'User does not appear to have a CID in their nick, sorry'
+            content: "User does not have an associated CID through VATSIM, sorry 😞"
         });
         return;
     }
-
-    const cid = parts[1];
 
     await interaction.reply({
         ephemeral: true,

--- a/src/types/maybe.ts
+++ b/src/types/maybe.ts
@@ -1,0 +1,1 @@
+export type Maybe<T> = NonNullable<T> | undefined;

--- a/src/util/cid_from_discord.ts
+++ b/src/util/cid_from_discord.ts
@@ -1,0 +1,11 @@
+// Theoretically CIDs are strings, funnily enough
+import {Maybe} from "../types/maybe";
+
+// TODO caching??
+export async function cidFromDiscord(id: string): Promise<Maybe<string>> {
+    const response = await fetch(`https://api.vatsim.net/v2/members/discord/${id}`);
+    if (!response.ok) {
+        return undefined;
+    }
+    return await response.json().then((x: Object): string => x['user_id']);
+}


### PR DESCRIPTION
Extracting CID from server nickname is rather unreliable. VATSIM provides an API that allows us to get the CID for any discord user ID that has linked their account through the community hub.
This makes it rather more reliable, and even functional in servers without the VATSIM bot.