### PR TITLE
Add caching throughout the app

### DIFF
--- a/src/commands/scenario/scenario.ts
+++ b/src/commands/scenario/scenario.ts
@@ -10,7 +10,7 @@ Data to collect for scenario generator:
 This gets fed into the script.
  */
 
-import "../../types/client";
+import "../../types/cache";
 import {Command} from "../../types/command";
 import {PublicAuthorization} from "../../authorization/authorize";
 import {

--- a/src/events/handlers/interactionCreate.ts
+++ b/src/events/handlers/interactionCreate.ts
@@ -8,7 +8,7 @@ import {
     Interaction
 } from "discord.js";
 import {EventHandler} from "../events";
-import "../../types/client";
+import "../../types/cache";
 import {AuthorizationType} from "../../authorization/authorize";
 import {Command} from "../../types/command";
 import {ContextMenu, contextMenuHandlers} from "../../context_menu/context_menu";

--- a/src/events/handlers/ready.ts
+++ b/src/events/handlers/ready.ts
@@ -1,4 +1,4 @@
-import '../../types/client';
+import '../../types/cache';
 
 import {Client, Events} from 'discord.js';
 import {EventHandler} from "../events";

--- a/src/scenario_generator/data/gates.ts
+++ b/src/scenario_generator/data/gates.ts
@@ -1,6 +1,5 @@
 import airports from "./airports";
-
-// TODO: probably also want caching here
+import "../../types/cache";
 
 export class Gate {
     public readonly altitude: string;
@@ -27,12 +26,16 @@ export class Gate {
 }
 
 export async function fetchGates(): Promise<Gate[]> {
+    if (global.cache.has('gates')) {
+        return global.cache.get('gates') as Gate[];
+    }
+
     const response = await fetch('https://api.beluxvacc.org/belux-gate-manager-api/gates/');
     if (!response.ok) {
         throw new Error(response.statusText);
     }
 
-    return await response.json()
+    const gates = await response.json()
         .then((body: Object[]): Gate[] =>
             body.map(x => new Gate(
                 x['airport'],
@@ -42,4 +45,6 @@ export async function fetchGates(): Promise<Gate[]> {
                 x['longitude'],
                 x['heading']
             )));
+    global.cache.set('gates', gates);
+    return gates;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import "./types/client";
+import "./types/cache";
 
 require('dotenv')
     .config();

--- a/src/types/cache.ts
+++ b/src/types/cache.ts
@@ -8,5 +8,16 @@ declare module 'discord.js' {
     }
 }
 
+declare global {
+    module NodeJS {
+        interface Global {
+            cache: Map<string, any>;
+        }
+    }
+}
+
+if (global.cache === undefined || global.cache === null) {
+    global.cache = new Map<string, any>();
+    Client.prototype.cache = global.cache;
+}
 Client.prototype.commands = new Collection<string, Command>();
-Client.prototype.cache = new Map<string, any>();

--- a/src/util/cid_from_discord.ts
+++ b/src/util/cid_from_discord.ts
@@ -1,11 +1,19 @@
 // Theoretically CIDs are strings, funnily enough
 import {Maybe} from "../types/maybe";
 
-// TODO caching??
 export async function cidFromDiscord(id: string): Promise<Maybe<string>> {
+    if (!global.cache.has('discord_cids'))
+        global.cache.set('discord_cids', new Map<string, string>);
+    const cached_cid = global.cache.get('discord_cids').get(id);
+    if (cached_cid !== undefined) {
+        return cached_cid;
+    }
+
     const response = await fetch(`https://api.vatsim.net/v2/members/discord/${id}`);
     if (!response.ok) {
         return undefined;
     }
-    return await response.json().then((x: Object): string => x['user_id']);
+    const cid = await response.json().then((x: Object): string => x['user_id']);
+    global.cache.get('discord_cids').set(id, cid);
+    return cid;
 }

--- a/src/workers/delete-messages.ts
+++ b/src/workers/delete-messages.ts
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import "../types/client";
+import "../types/cache";
 import {BaseGuildTextChannel, Channel, Client} from "discord.js";
 import config from "../util/config";
 

--- a/src/workers/live-stats.ts
+++ b/src/workers/live-stats.ts
@@ -1,4 +1,4 @@
-import "../types/client";
+import "../types/cache";
 import {APIEmbedField, BaseGuildTextChannel, Client, EmbedBuilder} from "discord.js";
 import {makeTimestamp, TimestampFormat} from "../util/timestamp";
 import config from "../util/config";


### PR DESCRIPTION
This stops excessive API calls for gate lists or discord-cid translations