### PR TITLE
Add newline before mentions in LoA message

### DIFF
--- a/src/commands/basic/loa.ts
+++ b/src/commands/basic/loa.ts
@@ -67,7 +67,7 @@ const execute = async (interaction: ChatInputCommandInteraction) => {
     infoMessage += `### ${loa}\n\n`;
     infoMessage += 'https://beluxvacc.org/controller-files/';
     if (text !== null) {
-        infoMessage += `\n\n${text}`;
+        infoMessage += `\n\n${text}\n`;
     }
     infoMessage += config.loa.mention_roles.map(x => `<@&${x}>`).join(' ');
 


### PR DESCRIPTION
Discord trims any trailing newlines from the comment text message, so to make sure the mentions end up on their own line, we force an extra newline.