### PR TITLE
Crosspost event messages if announcement channel

### DIFF
--- a/src/commands/events/publish.ts
+++ b/src/commands/events/publish.ts
@@ -2,7 +2,7 @@ import {SubCommand} from "../../types/command";
 import {
     BaseGuildTextChannel,
     ChannelType,
-    ChatInputCommandInteraction,
+    ChatInputCommandInteraction, DiscordAPIError,
     EmbedBuilder,
     SlashCommandSubcommandBuilder
 } from "discord.js";
@@ -74,13 +74,22 @@ export default {
             });
             return;
         }
-        await (channel as BaseGuildTextChannel).send({
+        const message = await (channel as BaseGuildTextChannel).send({
             embeds: [embed]
         });
         await interaction.reply({
             ephemeral: true,
             content: "👍 event posted!"
         });
+        try {
+            await message.crosspost();
+        } catch (e) {
+            await interaction.followUp({
+                ephemeral: true,
+                content: 'Could not crosspost, target channel is probably not an announcement channel'
+            });
+            console.log('Could not crosspost event, error: ' + e);
+        }
     }
 
 } satisfies SubCommand;


### PR DESCRIPTION
Apparently that's a workflow in use and requires an explicit API call. We log any errors to the user as target channel probably not being an announcement channel,
but log the actual cause in the server logs