### PR TITLE
Workarounds for Node Build Issues

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: PR Test Build
 
 on:
   pull_request:
@@ -9,5 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag stefpletinck/betty:$(git rev-parse HEAD)
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22.4.x
+    - name: Install dependencies
+      run: npm ci --include dev
+    - name: Build
+      run: npx tsup src/server.ts src/deploy-commands.ts --minify

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine as compile
+FROM node:22.4-alpine as compile
 RUN apk --no-cache add curl python3 build-base
 WORKDIR /usr/src/app
 COPY package*.json ./
@@ -6,13 +6,13 @@ RUN npm ci --include dev
 COPY . .
 RUN ["npx", "tsup", "src/server.ts", "src/deploy-commands.ts", "--minify"]
 
-FROM node:22-alpine as modules
+FROM node:22.4-alpine as modules
 RUN apk --no-cache add curl python3 build-base
 WORKDIR /usr/src/app
 COPY --from=compile /usr/src/app/package*.json ./
 RUN npm ci --omit dev
 
-FROM node:22-alpine
+FROM node:22.4-alpine
 RUN apk --no-cache add curl
 WORKDIR /usr/src/app
 COPY --from=modules /usr/src/app/node_modules ./node_modules


### PR DESCRIPTION
Node 22.5 was released recently and introduced https://github.com/npm/cli/issues/7657
This causes our PR _and_ release builds to fail.

As a workaround, we pin the docker builds to the (now unsupported) 22.4 base image,
and switch the PR action to a plain Node operation.