### PR TITLE
Fix undefined ReqAlt

### DIFF
--- a/src/scenario_generator/flight_selector.ts
+++ b/src/scenario_generator/flight_selector.ts
@@ -81,6 +81,7 @@ export class FlightSelector {
                     faults[x] ? this.faulter.fault(departures[x]) : departures[x]
                 )
                     .setStart(0)
+                    .setReqAlt("EBBR:" + airports[this.airport].departureAltitude)
                     .setInitialPseudoPilot(this.initialPseudoPilot)
                     .setPosition(this.gates.for(this.airport, departures[x]).toLocationString())
             );
@@ -174,6 +175,7 @@ export class FlightSelector {
                     .setStart((x + 1) * interval)
                     .setInitialPseudoPilot(this.initialPseudoPilot)
                     .setPosition(this.gates.for(this.airport, departures[x]).toLocationString())
+                    .setReqAlt(this.currentConfiguration.routes.vfr[0].reqAlt)
             );
         }
         this.selected.push(...toBeAdded);


### PR DESCRIPTION
ReqAlt must always be selected.
This commit ensures that initial flightplans have one, and VFR departures get the reqAlt of the first arrival route.