### PR TITLE
Fix not all roles being added to event threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The live stats feature requires:
 - send messages
 - embed links
 
+Betty needs the GUILD_MEMBERS privileged intent in order to get the members of a role.
+
 ### Deployment
 
 Betty is available as a Docker image under `stefpletinck/betty`.

--- a/src/commands/events/thread.ts
+++ b/src/commands/events/thread.ts
@@ -60,9 +60,13 @@ export default {
         if (interaction.member instanceof GuildMember) {
             await thread.members.add(interaction.member)
         }
+        // This is stupid, but somehow makes it work... Slowly and needing the GuildMember intent
+        await interaction.guild.members.fetch();
         for (const roleId of config.events.add_roles) {
             const role = await interaction.guild.roles.fetch(roleId);
-                role.members.each(async member => await thread.members.add(member))
+            for (const [_, member] of role.members) {
+                await thread.members.add(member);
+            }
         }
 
         await interaction.followUp({

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,16 @@ import {events} from './events/events';
 import deleteMessages from './workers/delete-messages';
 import {liveStats} from "./workers/live-stats";
 
-const client: Client = new Client({intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates]});
+const client: Client = new Client({
+    intents: [
+        // Needed for pretty much everything
+        GatewayIntentBits.Guilds,
+        // Used by the automatic voice channel moving, especially closing empty channels
+        GatewayIntentBits.GuildVoiceStates,
+        // Used to get members of a role
+        GatewayIntentBits.GuildMembers
+    ]
+});
 
 client.commands = new Collection();
 


### PR DESCRIPTION
This issue boils down to not having access to all members of a role. The only way around this that I found,
is allowing the GUILD_MEMBERS privileged intent (with all due consequences) and explicitly fetching all guild members before checking for role membership.

This slows down the command somewhat and adds a privileged intent, but seems necessary.